### PR TITLE
Fix --amount param of stake command to handle bigger values

### DIFF
--- a/command/sidechain/staking/params.go
+++ b/command/sidechain/staking/params.go
@@ -16,7 +16,7 @@ type stakeParams struct {
 	accountDir      string
 	accountConfig   string
 	jsonRPC         string
-	amount          uint64
+	amount          string
 	self            bool
 	delegateAddress string
 }

--- a/command/sidechain/staking/stake.go
+++ b/command/sidechain/staking/stake.go
@@ -11,6 +11,7 @@ import (
 	sidechainHelper "github.com/0xPolygon/polygon-edge/command/sidechain"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	"github.com/0xPolygon/polygon-edge/contracts"
+	"github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/spf13/cobra"
@@ -59,10 +60,10 @@ func setFlags(cmd *cobra.Command) {
 		"indicates if its a self stake action",
 	)
 
-	cmd.Flags().Uint64Var(
+	cmd.Flags().StringVar(
 		&params.amount,
 		sidechainHelper.AmountFlag,
-		0,
+		"0",
 		"amount to stake or delegate to another account",
 	)
 
@@ -113,11 +114,16 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
+	parsedValue, err := common.ParseUint256orHex(&params.amount)
+	if err != nil {
+		return fmt.Errorf("cannot parse \"amount\" value %s", params.amount)
+	}
+
 	txn := &ethgo.Transaction{
 		From:     validatorAccount.Ecdsa.Address(),
 		Input:    encoded,
 		To:       (*ethgo.Address)(&contracts.ValidatorSetContract),
-		Value:    new(big.Int).SetUint64(params.amount),
+		Value:    parsedValue,
 		GasPrice: sidechainHelper.DefaultGasPrice,
 	}
 


### PR DESCRIPTION
# Description

--amount param was set as uint64 which doesn't allow using big enough numbers. Fixed.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

Execute the command with different values

