### PR TITLE
change the method used for total stake fetching

### DIFF
--- a/consensus/polybft/rewards_calculator.go
+++ b/consensus/polybft/rewards_calculator.go
@@ -86,12 +86,17 @@ func NewRewardsCalculator(logger hclog.Logger, blockchain blockchainBackend) Rew
 }
 
 func (r *rewardsCalculator) GetMaxReward(block *types.Header) (*big.Int, error) {
-	stakedBalance, err := r.getStakedBalance(block)
+	systemState, err := r.getSystemState(block)
 	if err != nil {
 		return nil, err
 	}
 
-	baseReward, err := r.getMaxBaseReward(block)
+	stakedBalance, err := r.getStakedBalance(block, systemState)
+	if err != nil {
+		return nil, err
+	}
+
+	baseReward, err := r.getMaxBaseReward(block, systemState)
 	if err != nil {
 		return nil, err
 	}
@@ -101,12 +106,12 @@ func (r *rewardsCalculator) GetMaxReward(block *types.Header) (*big.Int, error) 
 		return nil, err
 	}
 
-	rsiBonus, err := r.getMaxRSIBonus(block)
+	rsiBonus, err := r.getMaxRSIBonus(block, systemState)
 	if err != nil {
 		return nil, err
 	}
 
-	macroFactor, err := r.getMacroFactor(block)
+	macroFactor, err := r.getMacroFactor(block, systemState)
 	if err != nil {
 		return nil, err
 	}
@@ -116,12 +121,7 @@ func (r *rewardsCalculator) GetMaxReward(block *types.Header) (*big.Int, error) 
 	return reward, nil
 }
 
-func (r *rewardsCalculator) getStakedBalance(block *types.Header) (*big.Int, error) {
-	systemState, err := r.getSystemState(block)
-	if err != nil {
-		return nil, err
-	}
-
+func (r *rewardsCalculator) getStakedBalance(block *types.Header, systemState SystemState) (*big.Int, error) {
 	reward, err := systemState.GetStakedBalance()
 	if err != nil {
 		return nil, err
@@ -130,12 +130,7 @@ func (r *rewardsCalculator) getStakedBalance(block *types.Header) (*big.Int, err
 	return reward, nil
 }
 
-func (r *rewardsCalculator) getMaxBaseReward(block *types.Header) (*BigNumDecimal, error) {
-	systemState, err := r.getSystemState(block)
-	if err != nil {
-		return nil, err
-	}
-
+func (r *rewardsCalculator) getMaxBaseReward(block *types.Header, systemState SystemState) (*BigNumDecimal, error) {
 	reward, err := systemState.GetBaseReward()
 	if err != nil {
 		return nil, err
@@ -150,12 +145,7 @@ func (r *rewardsCalculator) getVestingBonus(vestingWeeks uint64) (*big.Int, erro
 	return bonus, nil
 }
 
-func (r *rewardsCalculator) getMaxRSIBonus(block *types.Header) (*big.Int, error) {
-	systemState, err := r.getSystemState(block)
-	if err != nil {
-		return nil, err
-	}
-
+func (r *rewardsCalculator) getMaxRSIBonus(block *types.Header, systemState SystemState) (*big.Int, error) {
 	rsi, err := systemState.GetMaxRSI()
 	if err != nil {
 		return nil, err
@@ -164,12 +154,7 @@ func (r *rewardsCalculator) getMaxRSIBonus(block *types.Header) (*big.Int, error
 	return rsi, nil
 }
 
-func (r *rewardsCalculator) getMacroFactor(block *types.Header) (*big.Int, error) {
-	systemState, err := r.getSystemState(block)
-	if err != nil {
-		return nil, err
-	}
-
+func (r *rewardsCalculator) getMacroFactor(block *types.Header, systemState SystemState) (*big.Int, error) {
 	reward, err := systemState.GetMacroFactor()
 	if err != nil {
 		return nil, err

--- a/consensus/polybft/sc_integration_test.go
+++ b/consensus/polybft/sc_integration_test.go
@@ -383,17 +383,9 @@ func TestIntegration_CommitEpoch(t *testing.T) {
 			}
 		}
 
-		// Get total active staked amount
-		encoded, err := hex.DecodeHex("28f73148") // totalActiveStake()
-		require.NoError(t, err)
-		activeStakeRes := transition.Call2(types.Address{0x0}, contracts.ValidatorSetContract, encoded, nil, 1000000000000)
-		require.False(t, activeStakeRes.Failed())
-		totalActiveStake := new(big.Int).SetBytes(activeStakeRes.ReturnValue)
-
-		commitEpochTxValue := createTestCommitEpochTxValue(t, totalActiveStake)
-
-		commitEpoch := createTestCommitEpochInputWithVals(t, 1, accSet, polyBFTConfig.EpochSize)
-		input, err := commitEpoch.EncodeAbi()
+		commitEpochTxValue := createTestCommitEpochTxValue(t, transition)
+		commitEpochInput := createTestCommitEpochInputWithVals(t, 1, accSet, polyBFTConfig.EpochSize)
+		input, err := commitEpochInput.EncodeAbi()
 		require.NoError(t, err)
 
 		// Normally injecting balance to the system caller is handled by a higher order method in the executor.go
@@ -405,8 +397,8 @@ func TestIntegration_CommitEpoch(t *testing.T) {
 		require.NoError(t, result.Err)
 		t.Logf("Number of validators %d when we add %d of delegators, Gas used %+v\n", accSet.Len(), accSet.Len()*delegatorsPerValidator, result.GasUsed)
 
-		commitEpoch = createTestCommitEpochInputWithVals(t, 2, accSet, polyBFTConfig.EpochSize)
-		input, err = commitEpoch.EncodeAbi()
+		commitEpochInput = createTestCommitEpochInputWithVals(t, 2, accSet, polyBFTConfig.EpochSize)
+		input, err = commitEpochInput.EncodeAbi()
 		require.NoError(t, err)
 
 		transition.Txn().AddBalance(contracts.SystemCaller, commitEpochTxValue)

--- a/consensus/polybft/system_state.go
+++ b/consensus/polybft/system_state.go
@@ -171,12 +171,12 @@ func (s *SystemStateImpl) GetMaxRSI() (maxRSI *big.Int, err error) {
 
 // GetStakedBalance H: fetch the total staked balance from the validators contract
 func (s *SystemStateImpl) GetStakedBalance() (*big.Int, error) {
-	rawOutput, err := s.validatorContract.Call("totalStake", ethgo.Latest)
+	rawOutput, err := s.validatorContract.Call("totalActiveStake", ethgo.Latest)
 	if err != nil {
 		return nil, err
 	}
 
-	stake, ok := rawOutput["0"].(*big.Int)
+	stake, ok := rawOutput["activeStake"].(*big.Int)
 	if !ok {
 		return nil, fmt.Errorf("failed to decode total stake")
 	}


### PR DESCRIPTION
# Description

change the method used for total stake fetching
modify sc integration tests to test the rewards_calculator as well
improve reward calculator and its tests

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

